### PR TITLE
has_parent 描述错误

### DIFF
--- a/404_Parent_Child/55_Has_parent.asciidoc
+++ b/404_Parent_Child/55_Has_parent.asciidoc
@@ -1,7 +1,7 @@
 [[has-parent]]
 === 通过父文档查询子文档
 
-虽然 `nested` 查询只能返回最顶层的文档 ((("parent-child relationship", "finding children by their parents")))，但是父文档和子文档本身是彼此独立并且可被单独查询的。我们使用 `has_child` 语句可以基于子文档来查询父文档，使用 `has_parent` 语句可以基于子文档来查询父文档。 ((("has_parent query and filter", "query")))
+虽然 `nested` 查询只能返回最顶层的文档 ((("parent-child relationship", "finding children by their parents")))，但是父文档和子文档本身是彼此独立并且可被单独查询的。我们使用 `has_child` 语句可以基于子文档来查询父文档，使用 `has_parent` 语句可以基于父文档来查询子文档。 ((("has_parent query and filter", "query")))
 
 `has_parent` 和 `has_child` 非常相似，下面的查询将会返回所有在 UK 工作的雇员：
 


### PR DESCRIPTION
使用 `has_parent` 语句可以基于父文档来查询子文档。

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
