### PR TITLE
Update 35_Search_as_you_type.asciidoc

### DIFF
--- a/130_Partial_Matching/35_Search_as_you_type.asciidoc
+++ b/130_Partial_Matching/35_Search_as_you_type.asciidoc
@@ -261,7 +261,7 @@ Elasticsearch ((("completion suggester")))里的 {ref}/search-suggesters-complet
 
 ==== 边界 n-grams 与邮编
 
-边界 n-gram 的方式可以用来查询结构化的数据，((("postcodes (UK), partial matching with", "using edge n-grams")))((("edge n-grams", "and postcodes")))比如 <<prefix-query,本章之前示例>> 中的邮编（postcode）。当然 `postcode` 字段需要 `analyzed` 而不是 `not_analyzed` ，不过可以用 `keyword` 分词器来处理它，就好像他们是 `not_analyzed` 的一样。((("keyword tokenizer", "using for values treated as not_analyzed")))((("not_analyzed fields", "using keyword tokenizer with")))
+边界 n-gram 的方式可以用来查询结构化的数据，((("postcodes (UK), partial matching with", "using edge n-grams")))((("edge n-grams", "and postcodes")))比如 <<prefix-query,本章之前示例>> 中的邮编（postcode）。当然 `postcode` 字段需要 `not_analyzed` 而不是 `analyzed` ，不过可以用 `keyword` 分词器来处理它，就好像他们是 `not_analyzed` 的一样。((("keyword tokenizer", "using for values treated as not_analyzed")))((("not_analyzed fields", "using keyword tokenizer with")))
 
 [TIP]
 ==================================================


### PR DESCRIPTION
按照上下文理解, keyword分词器是把查询词当做`not_analyzed`字段处理的, 那postcode为了像keyword一样, 也应该是把字段当做`not_analyzed`处理而不是`analyzed`, 文章是不是写反了?

<!--
Thanks for the Pull Request!  We really appreciate your help and contribution!

Before you submit the PR, have you signed Contributor License Agreement: https://www.elastic.co/contributor-agreement/ ?

PR's (no matter how small) cannot be merged until the CLA has been signed.  
It only needs to be signed once, however. Thanks!
-->
